### PR TITLE
Failing example with relative import

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "ts-node tooling/specialpurpose.ts"
   },
   "repository": {
     "type": "git",

--- a/tooling/lib/util.ts
+++ b/tooling/lib/util.ts
@@ -1,0 +1,3 @@
+export function utilityFunction(){
+    console.log("Hello World!");
+}

--- a/tooling/specialpurpose.ts
+++ b/tooling/specialpurpose.ts
@@ -1,0 +1,3 @@
+import { utilityFunction } from "./lib/util"
+
+utilityFunction()


### PR DESCRIPTION
Running `npm install && npm run test` in this repo demonstrates the need for relative typescript imports to use a `.js` suffix even with the new version. This seems to violate the [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) enough that a fix would be valuable.